### PR TITLE
debian: use PYTHONUNBEFFERED instead of python -u

### DIFF
--- a/debian/wazo-setupd.service
+++ b/debian/wazo-setupd.service
@@ -4,8 +4,9 @@ After=network.target
 Before=monit.service
 
 [Service]
+Environment=PYTHONUNBUFFERED=TRUE
 ExecStartPre=/usr/bin/install -o wazo-setupd -g wazo-setupd -d /run/wazo-setupd
-ExecStart=/usr/bin/python3 -u /usr/bin/wazo-setupd
+ExecStart=/usr/bin/wazo-setupd
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
reason: to see the daemon name in the journalctl/syslog instead of
`python3`