### PR TITLE
raise when more than 2 nameservers

### DIFF
--- a/integration_tests/suite/test_setup.py
+++ b/integration_tests/suite/test_setup.py
@@ -84,7 +84,7 @@ class TestSetupErrors(BaseIntegrationTest):
         setupd = self.make_setupd(VALID_TOKEN)
         confd = self.make_confd()
         confd.set_wizard_discover({
-            "nameservers": ['10.2.2.2', '10.2.2.3', '10.2.2.4']
+            "nameservers": ['10.2.2.2', '10.2.2.3', '10.2.2.4', '10.2.2.5']
         })
         confd.set_wizard({
             'configured': False,

--- a/integration_tests/suite/test_setup.py
+++ b/integration_tests/suite/test_setup.py
@@ -80,6 +80,29 @@ class TestSetupErrors(BaseIntegrationTest):
             ))
         )
 
+    def test_setup_when_more_than_two_nameservers(self):
+        setupd = self.make_setupd(VALID_TOKEN)
+        confd = self.make_confd()
+        confd.set_wizard_discover({
+            "nameservers": ['10.2.2.2', '10.2.2.3', '10.2.2.4']
+        })
+        confd.set_wizard({
+            'configured': False,
+        })
+        body = {
+            'engine_language': 'en_US',
+            'engine_password': 'secret',
+            'engine_license': True,
+        }
+
+        assert_that(
+            calling(setupd.setup.create).with_args(body),
+            raises(SetupdError).matching(has_properties(
+                status_code=500,
+                error_id='setup-nameservers-failed',
+            ))
+        )
+
 
 class TestSetupValid(BaseIntegrationTest):
 

--- a/wazo_setupd/plugins/setup/services.py
+++ b/wazo_setupd/plugins/setup/services.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2019 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2020 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
@@ -109,6 +109,13 @@ class SetupService:
             return
 
         discover = c.wizard.discover()
+
+        if len(discover['nameservers']) > 2:
+            # NOTE(fblackburn): Should parse confd error when it will return json errors
+            raise SetupError(
+                message='Too many nameservers configured on host, maximum authorized is two',
+                error_id='setup-nameservers-failed',
+            )
 
         if not discover.get('domain'):
             discover['domain'] = 'localdomain'

--- a/wazo_setupd/plugins/setup/services.py
+++ b/wazo_setupd/plugins/setup/services.py
@@ -110,10 +110,10 @@ class SetupService:
 
         discover = c.wizard.discover()
 
-        if len(discover['nameservers']) > 2:
+        if len(discover['nameservers']) > 3:
             # NOTE(fblackburn): Should parse confd error when it will return json errors
             raise SetupError(
-                message='Too many nameservers configured on host, maximum authorized is two',
+                message='Too many nameservers configured on host, maximum authorized is three',
                 error_id='setup-nameservers-failed',
             )
 


### PR DESCRIPTION
the real impact is only to fail before wazo-confd and print a better
message error. The status code is still the same