### PR TITLE
fix issue with openapi null value

### DIFF
--- a/wazo_setupd/plugins/setup/api.yml
+++ b/wazo_setupd/plugins/setup/api.yml
@@ -48,7 +48,7 @@ definitions:
       engine_rtp_stunaddr:
         description: The address of the STUN server to use for WebRTC
         type: string
-        default: null
+        default: 'null'
       nestbox_host:
         description: Host of the Nestbox where the engine will register. Specifying this key will make nestbox and `engine_internal_address` keys mandatory. Wazo will be connected to the specified Nestbox instance.
         type: string


### PR DESCRIPTION
With recent swagger version it's fixed. But for now, it avoid to load the spec