### PR TITLE
test: remove unused rabbitmq container

### DIFF
--- a/integration_tests/assets/docker-compose.base.override.yml
+++ b/integration_tests/assets/docker-compose.base.override.yml
@@ -7,9 +7,8 @@ services:
       - nestbox
       - nestbox-auth
       - nestbox-deployd
-      - rabbitmq
       - setupd
       - sysconfd
       - webhookd
     environment:
-      TARGETS: rabbitmq:5672 webhookd:9300 confd:9486 setupd:9302 nestbox:443 nestbox-auth:9497 nestbox-deployd:9800 auth:9497 sysconfd:8668
+      TARGETS: webhookd:9300 confd:9486 setupd:9302 nestbox:443 nestbox-auth:9497 nestbox-deployd:9800 auth:9497 sysconfd:8668

--- a/integration_tests/assets/docker-compose.short-self-stop.override.yml
+++ b/integration_tests/assets/docker-compose.short-self-stop.override.yml
@@ -6,12 +6,11 @@ services:
       - nestbox
       - nestbox-auth
       - nestbox-deployd
-      - rabbitmq
       - setupd
       - sysconfd
       - webhookd
     environment:
-      TARGETS: rabbitmq:5672 webhookd:9300 confd:9486 setupd:9302 nestbox:443 nestbox-auth:9497 nestbox-deployd:9800 sysconfd:8668
+      TARGETS: webhookd:9300 confd:9486 setupd:9302 nestbox:443 nestbox-auth:9497 nestbox-deployd:9800 sysconfd:8668
 
   setupd:
     volumes:

--- a/integration_tests/assets/docker-compose.yml
+++ b/integration_tests/assets/docker-compose.yml
@@ -40,14 +40,6 @@ services:
     ports:
       - '9486'
 
-  rabbitmq:
-    image: rabbitmq
-    ports:
-      - '5672'
-    volumes:
-      - type: tmpfs
-        target: /var/lib/rabbitmq
-
   setupd:
     image: wazo-setupd-test
     environment:

--- a/integration_tests/assets/etc/wazo-setupd/conf.d/50-default-config.yml
+++ b/integration_tests/assets/etc/wazo-setupd/conf.d/50-default-config.yml
@@ -7,7 +7,5 @@ confd:
   host: confd
 sysconfd:
   host: sysconfd
-bus:
-  host: rabbitmq
 service_discovery:
   enabled: false

--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -8,8 +8,6 @@ from wazo_setupd_client import Client as SetupdClient
 from xivo_test_helpers import until
 from xivo_test_helpers.asset_launching_test_case import AssetLaunchingTestCase
 from xivo_test_helpers.auth import AuthClient
-from xivo_test_helpers.bus import BusClient
-
 from .confd import ConfdMockClient
 from .deployd import DeploydMockClient
 from .sysconfd import SysconfdMockClient
@@ -46,11 +44,6 @@ class BaseIntegrationTest(AssetLaunchingTestCase):
     def make_auth(self):
         return AuthClient('127.0.0.1', self.service_port(9497, 'nestbox-auth'))
 
-    def make_bus(self):
-        return BusClient.from_connection_fields(
-            host='127.0.0.1', port=self.service_port(5672, 'rabbitmq')
-        )
-
     def make_confd(self):
         return ConfdMockClient('127.0.0.1', self.service_port(9486, 'confd'))
 
@@ -72,11 +65,3 @@ class BaseIntegrationTest(AssetLaunchingTestCase):
         self.start_service('auth')
         auth = self.make_auth()
         until.true(auth.is_up, tries=5, message='wazo-auth did not come back up')
-
-    @contextmanager
-    def rabbitmq_stopped(self):
-        self.stop_service('rabbitmq')
-        yield
-        self.start_service('rabbitmq')
-        bus = self.make_bus()
-        until.true(bus.is_up, tries=5, message='rabbitmq did not come back up')


### PR DESCRIPTION
why: only use for service_discovery, but not tested