### PR TITLE
tests: do not use docker volumes

### DIFF
--- a/integration_tests/assets/docker-compose.yml
+++ b/integration_tests/assets/docker-compose.yml
@@ -31,9 +31,6 @@ services:
     image: wazoplatform/wazo-auth-mock
     ports:
       - '9497'
-    volumes:
-      - setupd-generated-config:/usr/share/wazo-setupd:ro
-      - auth-config:/etc/wazo-auth/conf.d:ro
 
   confd:
     image: wazoplatform/wazo-confd-mock
@@ -47,10 +44,6 @@ services:
     volumes:
       - ../..:/usr/src/wazo-setupd:ro
       - ./etc/wazo-setupd/conf.d/50-default-config.yml:/etc/wazo-setupd/conf.d/50-default-config.yml:ro
-      - auth-config:/etc/wazo-auth/conf.d
-      - webhookd-config:/etc/wazo-webhookd/conf.d
-      - nestbox-plugin-config:/etc/wazo-nestbox-plugin/conf.d
-      - setupd-generated-config:/usr/share/wazo-setupd
       # - '${LOCAL_GIT_REPOS}/xivo-lib-python/xivo:/opt/venv/lib/python3.7/site-packages/xivo'
     ports:
       - '9302'
@@ -64,13 +57,4 @@ services:
     image: wazoplatform/wazo-webhookd-mock
     ports:
       - '9300'
-    volumes:
-      - setupd-generated-config:/usr/share/wazo-setupd:ro
-      - webhookd-config:/etc/wazo-webhookd/conf.d:ro
     command: /usr/local/bin/wazo-webhookd-mock.py 9300
-
-volumes:
-  setupd-generated-config:
-  auth-config:
-  webhookd-config:
-  nestbox-plugin-config:

--- a/integration_tests/docker/wazo-webhookd-mock/Dockerfile
+++ b/integration_tests/docker/wazo-webhookd-mock/Dockerfile
@@ -3,7 +3,10 @@ FROM p0bailey/docker-flask
 MAINTAINER Wazo Maintainers <dev@wazo.community>
 
 COPY requirements.txt /tmp/requirements.txt
-RUN pip install -r /tmp/requirements.txt
+RUN true && \
+    pip install -r /tmp/requirements.txt && \
+    mkdir -p /etc/wazo-webhookd/conf.d && \
+    true
 
 EXPOSE 9300
 COPY wazo-webhookd-mock.py /usr/local/bin/wazo-webhookd-mock.py

--- a/integration_tests/suite/helpers/base.py
+++ b/integration_tests/suite/helpers/base.py
@@ -65,3 +65,24 @@ class BaseIntegrationTest(AssetLaunchingTestCase):
         self.start_service('auth')
         auth = self.make_auth()
         until.true(auth.is_up, tries=5, message='wazo-auth did not come back up')
+
+    def synchronize_setup_config_files(self):
+        """This function is a workaround for this docker bug:
+        https://github.com/moby/moby/issues/42119
+        When this bug happens, network are not removed correctly, and volumes
+        that should be removed after that are not removed. This makes the
+        volumes to be shared across tests, causing failures.
+        This function avoids the use of docker volumes altogether."""
+
+        self.docker_copy_across_containers(
+            'setupd',
+            '/usr/share/wazo-setupd/50-wazo-plugin-nestbox.yml',
+            'webhookd',
+            '/etc/wazo-webhookd/conf.d/50-wazo-plugin-nestbox.yml',
+        )
+        self.docker_copy_across_containers(
+            'setupd',
+            '/usr/share/wazo-setupd/50-wazo-plugin-nestbox.yml',
+            'auth',
+            '/etc/wazo-auth/conf.d/50-wazo-plugin-nestbox.yml',
+        )

--- a/integration_tests/suite/test_setup.py
+++ b/integration_tests/suite/test_setup.py
@@ -156,6 +156,7 @@ class TestSetupValid(BaseIntegrationTest):
         }
 
         setupd.setup.create(body)
+        self.synchronize_setup_config_files()
 
         assert_that(
             confd.requests().json(),
@@ -285,6 +286,7 @@ class TestSetupValid(BaseIntegrationTest):
         }
 
         setupd.setup.create(body)
+        self.synchronize_setup_config_files()
 
         assert_that(
             confd.requests().json(),
@@ -395,6 +397,7 @@ class TestSetupValidNoNestbox(BaseIntegrationTest):
         }
 
         setupd.setup.create(body)
+        self.synchronize_setup_config_files()
 
         assert_that(
             confd.requests().json(),


### PR DESCRIPTION
Why:

* This bug happens infrequently: https://github.com/moby/moby/issues/42119
* This causes networks to not be removed at the end of a test.
* This causes volumes to not be removed at the end of a test.
* This causes tests to reuse volumes of previous tests, leading to
failures.