### PR TITLE
integration tests: avoid self-stop interference

### DIFF
--- a/integration_tests/suite/helpers/wait_strategy.py
+++ b/integration_tests/suite/helpers/wait_strategy.py
@@ -1,5 +1,12 @@
-# Copyright 2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2021 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
+
+from hamcrest import (
+    assert_that,
+    has_entries,
+    has_entry,
+)
+from xivo_test_helpers import until
 
 
 class WaitStrategy:
@@ -10,3 +17,19 @@ class WaitStrategy:
 class NoWaitStrategy(WaitStrategy):
     def wait(self, setupd):
         pass
+
+
+class SetupdEverythingOkWaitStrategy(WaitStrategy):
+    def wait(self, setupd):
+        def setupd_is_ready():
+            status = setupd.status.get()
+            assert_that(
+                status,
+                has_entries(
+                    {
+                        'rest_api': has_entry('status', 'ok'),
+                    }
+                ),
+            )
+
+        until.assert_(setupd_is_ready, tries=60)

--- a/integration_tests/suite/test_setup.py
+++ b/integration_tests/suite/test_setup.py
@@ -20,7 +20,10 @@ from .helpers.base import (
     BaseIntegrationTest,
     VALID_TOKEN,
 )
-from .helpers.wait_strategy import NoWaitStrategy
+from .helpers.wait_strategy import (
+    NoWaitStrategy,
+    SetupdEverythingOkWaitStrategy,
+)
 
 from wazo_setupd_client.exceptions import SetupdError
 
@@ -107,12 +110,15 @@ class TestSetupErrors(BaseIntegrationTest):
 class TestSetupValid(BaseIntegrationTest):
 
     asset = 'base'
-    wait_strategy = NoWaitStrategy()
+    wait_strategy = SetupdEverythingOkWaitStrategy()
 
     def setUp(self):
         super().setUp()
+
         deployd = self.make_deployd()
         deployd.reset()
+
+        self.restart_service('setupd')  # avoid self-stop after test
 
     def test_setup_valid(self):
         setupd = self.make_setupd(VALID_TOKEN)


### PR DESCRIPTION
Why:

* When running multiple valid setup tests successively, the self-stop
mechanism will trigger, failing the later tests