### PR TITLE
use docker-compose from binary instead of python

### DIFF
--- a/integration_tests/suite/test_setup.py
+++ b/integration_tests/suite/test_setup.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import uuid
@@ -119,6 +119,8 @@ class TestSetupValid(BaseIntegrationTest):
         deployd.reset()
 
         self.restart_service('setupd')  # avoid self-stop after test
+        setupd = self.make_setupd(VALID_TOKEN)
+        self.wait_strategy.wait(setupd)
 
     def test_setup_valid(self):
         setupd = self.make_setupd(VALID_TOKEN)

--- a/integration_tests/test-requirements.txt
+++ b/integration_tests/test-requirements.txt
@@ -1,4 +1,3 @@
-docker-compose
 kombu
 openapi-spec-validator
 pyhamcrest

--- a/wazo_setupd/config.py
+++ b/wazo_setupd/config.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2021 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import argparse
@@ -23,6 +23,7 @@ _DEFAULT_CONFIG = {
         'prefix': None,
         'https': False,
         'key_file': '/var/lib/wazo-auth-keys/wazo-setupd-key.yml',
+        'master_tenant_uuid': None,
     },
     'bus': {
         'username': 'guest',


### PR DESCRIPTION
why: to have the latest docker-compose