### PR TITLE
Wazo-2638: Migration of wazo-setupd from Marshmallow 3.0.0b14 to stable version 3.10.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ itsdangerous==0.24  # from flask
 jinja2==2.10
 kombu==4.6.11
 markupsafe==1.1.0  # from flask
-marshmallow==3.0.0b14
+marshmallow==3.10.0
 python-consul==0.7.1
 pyyaml==3.13
 stevedore==1.29.0

--- a/wazo_setupd/plugins/setup/schemas.py
+++ b/wazo_setupd/plugins/setup/schemas.py
@@ -43,7 +43,7 @@ class SetupSchema(Schema):
     )
 
     @validates_schema
-    def nestbox_all_or_nothing(self, data):
+    def nestbox_all_or_nothing(self, data, **kwargs):
         if not data.get('nestbox_host'):
             return
 
@@ -69,7 +69,7 @@ class SetupSchema(Schema):
             )
 
     @validates_schema
-    def check_rtp_fields(self, data):
+    def check_rtp_fields(self, data, **kwargs):
         if not data.get('engine_rtp_icesupport'):
             return
 


### PR DESCRIPTION
Depends-On: https://github.com/wazo-platform/xivo-lib-python/pull/93