### PR TITLE
pin markupsafe version to buster

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,6 +11,7 @@ flask==1.0.2
 itsdangerous==0.24  # from flask
 jinja2==2.10
 kombu==4.6.11
+markupsafe==1.1.0  # from flask
 marshmallow==3.0.0b14
 python-consul==0.7.1
 pyyaml==3.13


### PR DESCRIPTION
why: if not pinned, pip install latest version (2.1.0) which is
incompatible with flask 1.0.2 and jinja2 from buster