### PR TITLE
README: remove section about getting the image

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,6 @@ A micro service to initialize a [Wazo](http://wazo.community) Engine.
 The official docker image for this service is `wazoplatform/wazo-setupd`.
 
 
-### Getting the image
-
-To download the latest image from the docker hub
-
-```sh
-docker pull wazoplatform/wazo-setupd
-```
-
-
 ### Running wazo-setupd
 
 ```sh


### PR DESCRIPTION
why: not available on docker hub
On cloud env, not sure if we want to use this image or not versus init wazo through env variables
Can be reverted the day we decide to push the image on hub