### PR TITLE
test: use mock from unittest library

### DIFF
--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,3 +1,2 @@
-mock
 pyhamcrest
 pytest

--- a/wazo_setupd/tests/test_controller.py
+++ b/wazo_setupd/tests/test_controller.py
@@ -1,8 +1,8 @@
-# Copyright 2018 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 from unittest import TestCase
-from mock import Mock
+from unittest.mock import Mock
 
 from ..controller import _sigterm_handler
 


### PR DESCRIPTION
why: pypi version is a backport if the python3 builtin package