### PR TITLE
disable consul/service_discovery by default

### DIFF
--- a/debian/wazo-setupd.links
+++ b/debian/wazo-setupd.links
@@ -1,2 +1,0 @@
-/var/lib/consul/default_xivo_consul_config.yml /etc/wazo-setupd/conf.d/050-xivo-consul-config.yml
-/var/lib/consul/default_xivo_consul_token.yml /etc/wazo-setupd/conf.d/050-xivo-consul-token.yml

--- a/etc/wazo-setupd/config.yml
+++ b/etc/wazo-setupd/config.yml
@@ -66,12 +66,12 @@ enabled_plugins:
 service_discovery:
   enabled: false
 
-# Example of service discovery settings
+# Example settings to enable service discovery
 #
 # Necessary to use service discovery
 # consul:
 #   scheme: http
-#   host: localhost
+#   host: consul.example.com
 #   port: 8500
 #   token: 'the_one_ring'
 #

--- a/etc/wazo-setupd/config.yml
+++ b/etc/wazo-setupd/config.yml
@@ -34,13 +34,6 @@ confd:
   prefix: null
   https: false
 
-# consul connection settings
-consul:
-  scheme: http
-  host: localhost
-  port: 8500
-  token: 'the_one_ring'
-
 # REST API server settings
 rest_api:
 
@@ -59,28 +52,6 @@ rest_api:
     # Allow JSON preflight requests
     allow_headers: [Content-Type, X-Auth-Token]
 
-# Service discovery configuration. all time intervals are in seconds
-service_discovery:
-  # Indicates whether of not to use service discovery.
-  # It should only be disabled for testing purposes
-  enabled: true
-  # The address that will be received by other services using service discovery.
-  # Use "advertise_address: auto" to enable ip address detection based on
-  # advertise_address_interface
-  advertise_address: auto
-  # If advertise_address is "auto" this interface will be used to find the ip
-  # address to advertise. Ignored otherwise
-  advertise_address_interface: eth0
-  advertise_port: 9302
-  # The number of seconds that consul will wait between 2 ttl messages to mark
-  # this service as up
-  ttl_interval: 30
-  # The time interval before the service sends a new ttl message to consul
-  refresh_interval: 27
-  # The time interval to detect that the service is running when starting
-  retry_interval: 2
-  extra_tags: []
-
 # System configuration server connection settings
 sysconfd:
   host: localhost
@@ -91,3 +62,36 @@ enabled_plugins:
   config: true
   setup: true
   status: true
+
+service_discovery:
+  enabled: false
+
+# Example of service discovery settings
+#
+# Necessary to use service discovery
+# consul:
+#   scheme: http
+#   host: localhost
+#   port: 8500
+#   token: 'the_one_ring'
+#
+# # All time intervals are in seconds
+# service_discovery:
+#   # Indicates whether of not to use service discovery.
+#   enabled: true
+#   # The address that will be received by other services using service discovery.
+#   # Use "advertise_address: auto" to enable ip address detection based on
+#   # advertise_address_interface
+#   advertise_address: auto
+#   # If advertise_address is "auto" this interface will be used to find the ip
+#   # address to advertise. Ignored otherwise
+#   advertise_address_interface: eth0
+#   advertise_port: 9302
+#   # The number of seconds that consul will wait between 2 ttl messages to mark
+#   # this service as up
+#   ttl_interval: 30
+#   # The time interval before the service sends a new ttl message to consul
+#   refresh_interval: 27
+#   # The time interval to detect that the service is running when starting
+#   retry_interval: 2
+#   extra_tags: []

--- a/integration_tests/assets/etc/wazo-setupd/conf.d/50-default-config.yml
+++ b/integration_tests/assets/etc/wazo-setupd/conf.d/50-default-config.yml
@@ -8,5 +8,3 @@ confd:
   host: confd
 sysconfd:
   host: sysconfd
-service_discovery:
-  enabled: false

--- a/wazo_setupd/config.py
+++ b/wazo_setupd/config.py
@@ -35,7 +35,6 @@ _DEFAULT_CONFIG = {
         'exchange_headers_name': 'wazo-headers',
     },
     'confd': {'host': 'localhost', 'port': 9486, 'prefix': None, 'https': False},
-    'consul': {'scheme': 'http', 'host': 'localhost', 'port': 8500},
     'rest_api': {
         'listen': '127.0.0.1',
         'port': _DEFAULT_HTTP_PORT,
@@ -43,11 +42,15 @@ _DEFAULT_CONFIG = {
         'private_key': None,
         'cors': {'enabled': True, 'allow_headers': ['Content-Type', 'X-Auth-Token']},
     },
+    'consul': {
+        'scheme': 'http',
+        'port': 8500,
+    },
     'service_discovery': {
+        'enabled': False,
         'advertise_address': 'auto',
         'advertise_address_interface': 'eth0',
         'advertise_port': _DEFAULT_HTTP_PORT,
-        'enabled': True,
         'ttl_interval': 30,
         'refresh_interval': 27,
         'retry_interval': 2,


### PR DESCRIPTION
why: consul is not used in default install
- Remove host key from default consul setting to block service start if
  not defined
- Keep common service_discovery and consul key in config.py to avoid
  to redefine everything when using these settings