### PR TITLE
docker: ignore .tox

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,5 @@
 .git
+.tox
 integration_tests
 *.egg-info
 debian


### PR DESCRIPTION
Why:

* Causes tox to rebuild docker images even if not necessary