### PR TITLE
WAZO-3007: `setupd` publish to wazo headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 23.01
+
+* Bus configuration changed:
+
+  * key `exchange_name` is now `wazo-headers`
+  * key `exchange_type` was removed
+
 ## 22.01
 
 * New read only parameters have been added to the `/status` API:

--- a/etc/wazo-setupd/config.yml
+++ b/etc/wazo-setupd/config.yml
@@ -24,8 +24,7 @@ bus:
   password: guest
   host: localhost
   port: 5672
-  exchange_name: xivo
-  exchange_type: topic
+  exchange_name: wazo-headers
 
 # Configuration server connection settings
 confd:

--- a/wazo_setupd/config.py
+++ b/wazo_setupd/config.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2022 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2023 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import argparse
@@ -30,9 +30,8 @@ _DEFAULT_CONFIG = {
         'password': 'guest',
         'host': 'localhost',
         'port': 5672,
-        'exchange_name': 'xivo',
-        'exchange_type': 'topic',
-        'exchange_headers_name': 'wazo-headers',
+        'exchange_name': 'wazo-headers',
+        'exchange_type': 'headers',
     },
     'confd': {'host': 'localhost', 'port': 9486, 'prefix': None, 'https': False},
     'rest_api': {


### PR DESCRIPTION
Only changes to the configuration files, since bus is unused (for future?) in this service.  