### PR TITLE
Limit sqlalchemy to version 1 in tests

### DIFF
--- a/integration_tests/test-requirements.txt
+++ b/integration_tests/test-requirements.txt
@@ -4,7 +4,7 @@ openapi-spec-validator
 pyhamcrest
 pytest
 requests
-sqlalchemy
+sqlalchemy<2
 stevedore
 https://github.com/wazo-platform/wazo-auth-client/archive/master.zip
 https://github.com/wazo-platform/wazo-lib-rest-client/archive/master.zip


### PR DESCRIPTION
sqlalchemy version 2.0 needs work before the migration

https://docs.sqlalchemy.org/en/14/changelog/migration_20.html