### PR TITLE
Use nginx for internal wazo-auth requests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 26.09
+
+* Requests to wazo-auth now default to `localhost:80`, through nginx.
+
 ## 23.01
 
 * Bus configuration changed:

--- a/etc/wazo-setupd/config.yml
+++ b/etc/wazo-setupd/config.yml
@@ -14,8 +14,7 @@ self_stop_delay: 10.0
 # Authentication server connection settings
 auth:
   host: localhost
-  port: 9497
-  prefix: null
+  port: 80
   https: false
 
 # Event bus (AMQP) connection settings

--- a/integration_tests/assets/etc/wazo-setupd/conf.d/50-default-config.yml
+++ b/integration_tests/assets/etc/wazo-setupd/conf.d/50-default-config.yml
@@ -3,6 +3,8 @@ rest_api:
   listen: 0.0.0.0
 auth:
   host: auth
+  port: 9497
+  prefix: null
   key_file: /var/lib/wazo-auth-keys/wazo-setupd-key.yml
 confd:
   host: confd

--- a/wazo_setupd/config.py
+++ b/wazo_setupd/config.py
@@ -1,4 +1,4 @@
-# Copyright 2018-2023 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import argparse
@@ -19,8 +19,7 @@ _DEFAULT_CONFIG = {
     'self_stop_delay': 10.0,
     'auth': {
         'host': 'localhost',
-        'port': 9497,
-        'prefix': None,
+        'port': 80,
         'https': False,
         'key_file': '/var/lib/wazo-auth-keys/wazo-setupd-key.yml',
         'master_tenant_uuid': None,


### PR DESCRIPTION
Points requests to wazo-auth at the nginx internal entry point
(`localhost:80`) instead of the wazo-auth process port, in both the Python
defaults and the shipped `config.yml` (the YAML is loaded on top of the Python
defaults, so both must change).

The `prefix` override is dropped rather than set: `wazo-auth-client` already
defaults to `/api/auth`.

Depends on:

* wazo-platform/wazo-nginx#23 — the internal entry point itself
* wazo-platform/wazo-auth#449 — the wazo-auth location served on it

Both must be deployed before this merges, otherwise internal auth calls 404.
Ticket: TASK-504

Notes:

* Integration test assets now pin `port: 9497` and `prefix: null` explicitly:
  their stacks have no nginx, and those values used to come from the defaults
  changed here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how all internal auth traffic is reached at runtime; wrong deploy order or missing nginx/auth routing will break setup and token flows.
> 
> **Overview**
> **wazo-setupd** now talks to **wazo-auth** through nginx on `localhost:80` instead of the auth daemon port `9497`.
> 
> Python defaults in `config.py` and the shipped `etc/wazo-setupd/config.yml` both use `auth.port: 80`. The explicit `prefix: null` default is removed so `wazo-auth-client` can use its built-in `/api/auth` path.
> 
> Integration test config pins `port: 9497` and `prefix: null` because those stacks hit auth directly with no nginx. Changelog **26.09** documents the behavior change.
> 
> **Deploy order:** nginx internal auth entry and wazo-auth location must be live before this ships, or internal auth calls will fail.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 32c58b7739b080b2bf4de6d71bab408f2045174f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->