### PR TITLE
http: fix stop-before-start shutdown race

### DIFF
--- a/wazo_setupd/http_server.py
+++ b/wazo_setupd/http_server.py
@@ -1,8 +1,9 @@
-# Copyright 2018-2024 The Wazo Authors  (see the AUTHORS file)
+# Copyright 2018-2026 The Wazo Authors  (see the AUTHORS file)
 # SPDX-License-Identifier: GPL-3.0-or-later
 
 import logging
 import os
+import threading
 from datetime import timedelta
 
 from flask import Flask
@@ -28,6 +29,7 @@ class CoreRestApi:
         app.config.update(global_config)
         self._load_cors()
         self.server = None
+        self._stopped = threading.Event()
 
     def _load_cors(self):
         cors_config = dict(self.config.get('cors', {}))
@@ -56,8 +58,13 @@ class CoreRestApi:
         for route in http_helpers.list_routes(app):
             logger.debug(route)
 
+        if self._stopped.is_set():
+            logger.warning('stop requested during startup: not starting the server')
+            return
+
         self.server.start()
 
     def stop(self):
+        self._stopped.set()
         if self.server:
             self.server.stop()

--- a/wazo_setupd/tests/test_http_server.py
+++ b/wazo_setupd/tests/test_http_server.py
@@ -1,0 +1,44 @@
+# Copyright 2026 The Wazo Authors  (see the AUTHORS file)
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+from unittest.mock import patch
+
+import pytest
+
+from wazo_setupd.http_server import CoreRestApi
+
+
+@pytest.fixture
+def rest_api():
+    config = {
+        'rest_api': {
+            'listen': '127.0.0.1',
+            'port': 9302,
+            'certificate': None,
+            'private_key': None,
+            'cors': {'enabled': False},
+        },
+    }
+    return CoreRestApi(config)
+
+
+def test_stop_before_run_does_not_raise_and_sets_the_tombstone(rest_api):
+    rest_api.stop()
+
+    assert rest_api._stopped.is_set()
+
+
+@patch('wazo_setupd.http_server.wsgi')
+def test_run_after_stop_does_not_start_the_server(wsgi, rest_api):
+    rest_api.stop()
+    rest_api.run()
+
+    wsgi.WSGIServer.return_value.start.assert_not_called()
+
+
+@patch('wazo_setupd.http_server.wsgi')
+def test_stop_after_run_stops_the_server(wsgi, rest_api):
+    rest_api.run()
+    rest_api.stop()
+
+    wsgi.WSGIServer.return_value.stop.assert_called_once_with()


### PR DESCRIPTION
Why: a SIGTERM landing during startup was silently lost when stop()
ran before run() assigned self.server: the stop was a no-op, run()
then started the server with nothing left to stop it, and systemd
escalated to SIGKILL after TimeoutStopSec. The window was the whole
startup phase preceding run().

stop() now sets a tombstone before stopping the server, and run()
checks it after assigning self.server: whichever side loses the
race, either run() sees the tombstone or stop() sees a real server.

Same fix as wazo-auth (ITEM-589).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, localized lifecycle change to HTTP server startup/shutdown with matching tests; no auth or data-path changes.
> 
> **Overview**
> Fixes a **startup/shutdown race** where `SIGTERM` during `CoreRestApi` startup could be ignored: if `stop()` ran before `self.server` existed, shutdown was a no-op and `run()` still called `start()`, leaving systemd to hit `TimeoutStopSec` and `SIGKILL`.
> 
> `CoreRestApi` now keeps a **`threading.Event` tombstone** (`_stopped`). **`stop()`** always sets it, then stops the WSGI server when present. **`run()`** checks the tombstone after building `self.server` and **skips `start()`** with a warning if stop was requested during startup.
> 
> Adds unit tests for stop-before-run, run-after-stop (no `start()`), and stop-after-run (server stopped).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 111731af0c8d9449258e777753ae46bd91c744eb. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->